### PR TITLE
Refactor EMailer module to use Nodemailer and EJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
-    "@nestjs-modules/mailer": "^2.0.2",
     "@nestjs/common": "^11.1.3",
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.1.3",
@@ -39,6 +38,7 @@
     "google-auth-library": "^10.1.0",
     "ioredis": "^5.6.1",
     "mongoose": "^8.16.1",
+    "nodemailer": "^7.0.4",
     "otplib": "^12.0.1",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
@@ -56,6 +56,7 @@
     "@types/express": "^5.0.3",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.0.10",
+    "@types/nodemailer": "^6.4.17",
     "@types/passport-jwt": "^4.0.1",
     "@types/passport-local": "^1.0.38",
     "@types/qrcode": "^1.5.5",

--- a/src/e-mailer/e-mailer.module.ts
+++ b/src/e-mailer/e-mailer.module.ts
@@ -1,40 +1,8 @@
-import { MailerModule } from '@nestjs-modules/mailer';
-import { EjsAdapter } from '@nestjs-modules/mailer/dist/adapters/ejs.adapter';
 import { Module } from '@nestjs/common';
-import { ConfigModule, ConfigService } from '@nestjs/config';
-import { join } from 'path';
-import { AllConfigType } from 'src/config/config.type';
 import { EMailerService } from './e-mailer.service';
 
 @Module({
-  imports: [
-    MailerModule.forRootAsync({
-      imports: [ConfigModule],
-      useFactory: async (configService: ConfigService<AllConfigType>) => ({
-        transport: {
-          service: configService.getOrThrow('emailer.service', { infer: true }),
-          secure: false,
-          auth: {
-            user: configService.getOrThrow('emailer.user', { infer: true }),
-            pass: configService.getOrThrow('emailer.passkey', { infer: true }),
-          },
-        },
-        defaults: {
-          from: `"${configService.getOrThrow('emailer.username', {
-            infer: true,
-          })}" <${configService.getOrThrow('emailer.user', { infer: true })}>`,
-        },
-        template: {
-          dir: join(__dirname, '/templates'),
-          adapter: new EjsAdapter(),
-          options: {
-            strict: false,
-          },
-        },
-      }),
-      inject: [ConfigService],
-    }),
-  ],
   providers: [EMailerService],
+  exports: [EMailerService],
 })
 export class EMailerModule {}

--- a/src/e-mailer/e-mailer.service.ts
+++ b/src/e-mailer/e-mailer.service.ts
@@ -1,11 +1,28 @@
-import { MailerService } from '@nestjs-modules/mailer';
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { OnEvent } from '@nestjs/event-emitter';
+import * as ejs from 'ejs';
+import * as nodemailer from 'nodemailer';
+import { join } from 'path';
 import { EventPayloads } from 'src/common/interfaces/event-emitter/event-payloads.interface';
+import { AllConfigType } from 'src/config/config.type';
 
 @Injectable()
 export class EMailerService {
-  constructor(private readonly mailerService: MailerService) {}
+  private transporter: nodemailer.Transporter;
+
+  constructor(private readonly configService: ConfigService<AllConfigType>) {
+    this.transporter = nodemailer.createTransport({
+      service: this.configService.getOrThrow('emailer.service', {
+        infer: true,
+      }),
+      secure: false,
+      auth: {
+        user: this.configService.getOrThrow('emailer.user', { infer: true }),
+        pass: this.configService.getOrThrow('emailer.passkey', { infer: true }),
+      },
+    });
+  }
 
   @OnEvent('user.welcome')
   async welcomeEmail(data: EventPayloads['user.welcome']) {
@@ -13,13 +30,19 @@ export class EMailerService {
 
     const subject = `Welcome: ${email}`;
 
-    await this.mailerService.sendMail({
+    // Render the template
+    const templatePath = join(__dirname, 'templates', 'welcome.ejs');
+    const html = await ejs.renderFile(templatePath, { email });
+
+    const from = `"${this.configService.getOrThrow('emailer.username', {
+      infer: true,
+    })}" <${this.configService.getOrThrow('emailer.user', { infer: true })}>`;
+
+    await this.transporter.sendMail({
+      from,
       to: email,
       subject,
-      template: './welcome',
-      context: {
-        email,
-      },
+      html,
     });
   }
 }


### PR DESCRIPTION
Update the EMailer module to utilize Nodemailer for sending emails and EJS for templating, enhancing email functionality and maintainability.

The reason for this change is that @nestjs-modules/nodemailer package is deprecated